### PR TITLE
PF-103 Multiple jobs per fork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .config
 .yardoc
+.ruby-version
 Gemfile.lock
 InstalledFiles
 _yardoc
@@ -11,6 +12,7 @@ doc/
 lib/bundler/man
 pkg
 rdoc
+spec/redis-server.log
 spec/reports
 test/tmp
 test/version_tmp

--- a/lib/resque/plugins/round_robin/round_robin.rb
+++ b/lib/resque/plugins/round_robin/round_robin.rb
@@ -27,6 +27,7 @@ module Resque::Plugins
     DEFAULT_QUEUE_DEPTH = 0
     def should_work_on_queue? queuename
       return true if @queues.include? '*'  # workers with QUEUES=* are special and are not subject to queue depth setting
+      return false if Resque.data_store.queue_size(queuename) == 0
       max = DEFAULT_QUEUE_DEPTH
       unless ENV["RESQUE_QUEUE_DEPTH"].nil? || ENV["RESQUE_QUEUE_DEPTH"] == ""
         max = ENV["RESQUE_QUEUE_DEPTH"].to_i

--- a/lib/resque/plugins/round_robin/round_robin.rb
+++ b/lib/resque/plugins/round_robin/round_robin.rb
@@ -38,8 +38,6 @@ module Resque::Plugins
       Resque.data_store.queue_size(queuename) == 0
     end
 
-    def remove_empty_queue(queuename)
-
     DEFAULT_QUEUE_DEPTH = 20
     def max_qeueue_workers_for(queuename)
       default_max_workers = DEFAULT_QUEUE_DEPTH

--- a/lib/resque/plugins/round_robin/version.rb
+++ b/lib/resque/plugins/round_robin/version.rb
@@ -1,7 +1,7 @@
 module Resque
   module Plugins
     module RoundRobin
-      VERSION = "1.0.0"
+      VERSION = "1.0.1"
     end
   end
 end

--- a/lib/resque/plugins/round_robin/version.rb
+++ b/lib/resque/plugins/round_robin/version.rb
@@ -1,7 +1,7 @@
 module Resque
   module Plugins
     module RoundRobin
-      VERSION = "0.1.4"
+      VERSION = "1.0.0"
     end
   end
 end


### PR DESCRIPTION
Improve the efficiency of resque by handling multiple jobs per fork.

This is only applied to the webhook queues where we process multiple jobs from the same account - so there are no cross-account issues.

Pass `JOBS_PER_FORK` in environment to run more than one job per fork.